### PR TITLE
New popup handler

### DIFF
--- a/PSAVanCanBridgeMain.cpp
+++ b/PSAVanCanBridgeMain.cpp
@@ -33,6 +33,7 @@
 #include "src/Can/Handlers/CanDash3MessageHandler.h"
 #include "src/Can/Handlers/CanDash4MessageHandler.h"
 #include "src/Can/Handlers/CanParkingAidHandler.h"
+#include "src/Can/Handlers/CanDisplayPopupHandler2.h"
 #ifdef USE_NEW_AIRCON_DISPLAY_SENDER
 #include "src/Can/Handlers/CanAirConOnDisplayHandler.h"
 #else
@@ -269,6 +270,10 @@ void CANSendDataTaskFunction(void * parameter)
 
             #pragma region PopupMessage
 
+            if (dataToBridge.Rpm > 500) {
+            	canPopupHandler->SetEngineRunning(true);
+            }
+
             canPopupHandler->Process(currentTime);
 
             #pragma endregion
@@ -414,6 +419,8 @@ void CANSendIgnitionTaskFunction(void * parameter)
             dataToBridge.MileageByte1, 
             dataToBridge.MileageByte2, 
             dataToBridge.MileageByte3);
+
+        canPopupHandler->SetIgnition(true);
 
         if (ignition == 1 &&
             dataToBridge.OutsideTemperature <= 3 && 

--- a/src/Can/Handlers/CanDisplayPopupHandler2.h
+++ b/src/Can/Handlers/CanDisplayPopupHandler2.h
@@ -1,0 +1,283 @@
+// CanDisplayPopupHandler.h
+#ifndef _CanDisplayPopupHandler_h
+#define _CanDisplayPopupHandler_h
+
+#include <cppQueue.h>
+#include <ArduinoLog.h>
+#include "../AbstractCanMessageSender.h"
+#include "../Structs/CanDisplayStructs.h"
+#include "../../Helpers/CanDisplayPopupItem.h"
+
+const int CAN_POPUP_MESSAGE_TIME = 4000;
+const int CAN_POPUP_DOOR_MESSAGE_TIME = 5000; //it is not used anywhere, but remove this line requires a lot of changes in other files
+
+class CanDisplayPopupHandler {
+
+
+public:
+	CanDisplayPopupHandler() {
+		canMessageSender = NULL;
+		popupMessageQueue = NULL;
+		canSemaphore = NULL;
+	}
+
+	CanDisplayPopupHandler(AbstractCanMessageSender * msgSender) {
+
+		canMessageSender = msgSender;
+		popupMessageQueue = new Queue(sizeof(CanDisplayPopupItem), 20, FIFO); // Instantiate queue for popup messages
+		canSemaphore = xSemaphoreCreateMutex();
+	}
+
+	void QueueNewMessage(CanDisplayPopupItem item) {
+
+		if (item.MessageType == CAN_POPUP_MSG_RISK_OF_ICE) {
+			if (!riskOfIceShown) {
+				PushPopupMsg(&item, canSemaphore, popupMessageQueue);
+				riskOfIceShown = true;
+			}
+			return;
+		}
+
+		if (item.MessageType
+				== CAN_POPUP_MSG_DOORS_BOOT_BONNET_REAR_SCREEN_AND_FUEL_TANK_OPEN
+				&& item.DoorStatus1 != 0) {
+			if (IsPopupVisible() && canBeVisible)
+				HideCurrentPopupMessage();
+			ShowCanPopupMessage(item.Category, item.MessageType, item.KmToDisplay, item.DoorStatus1, item.DoorStatus2, item.DisplayTimeInMilliSeconds);
+			canBeVisible = false;
+			popupVisible = true;
+			return;
+
+		}
+
+		if (item.MessageType
+				== CAN_POPUP_MSG_DOORS_BOOT_BONNET_REAR_SCREEN_AND_FUEL_TANK_OPEN
+				&& item.DoorStatus1 == 0 && !canBeVisible) {
+			HideCanPopupMessage(item.MessageType, item.DoorStatus1,
+					item.DisplayTimeInMilliSeconds);
+			canBeVisible = true;
+			popupVisible = false;
+			return;
+
+		}
+
+		if (item.MessageType
+				== CAN_POPUP_MSG_DOORS_BOOT_BONNET_REAR_SCREEN_AND_FUEL_TANK_OPEN
+				&& item.DoorStatus1 == 0) {
+			//we need to ignore frames when doors are closed and popup just hides (commented line 85 in VanCarStatusWithTripComputerHandler.h because we need to know when door changes status from opened to closed),
+			//otherwise we are sending unnecessary frames
+			return;
+		}
+
+		if (item.MessageType
+				== CAN_POPUP_MSG_AUTOMATIC_HEADLAMP_LIGHTING_ACTIVATED) {
+			if (GetEngineRunning() && !automaticLightingShownOnEngineRunning) {
+				PushPopupMsg(&item, canSemaphore, popupMessageQueue);
+				automaticLightingShownOnEngineRunning = true;
+			}
+
+			if (GetIgnition() && !automaticLightingShownOnIgnition) {
+				PushPopupMsg(&item, canSemaphore, popupMessageQueue);
+				automaticLightingShownOnIgnition = true;
+				itemlight = item;
+
+			}
+
+			if (automaticLightingShownOnEngineRunning)
+				return;
+			if (automaticLightingShownOnIgnition)
+				return;
+		}
+
+		if (item.MessageType
+				== CAN_POPUP_MSG_AUTOMATIC_DOOR_LOCKING_ACTIVATED) {
+			if (GetEngineRunning() && !automaticDoorLockShownOnEngineRunning) {
+				PushPopupMsg(&item, canSemaphore, popupMessageQueue);
+				automaticDoorLockShownOnEngineRunning = true;
+			}
+
+			if (GetIgnition() && !automaticDoorLockShownOnIgnition) {
+				PushPopupMsg(&item, canSemaphore, popupMessageQueue);
+				automaticDoorLockShownOnIgnition = true;
+				itemdoor = item;
+
+			}
+
+			if (automaticDoorLockShownOnEngineRunning)
+				return;
+			if (automaticDoorLockShownOnIgnition)
+				return;
+		}
+
+		if ((millis() - previousCanPopupTime) > chillTime * 1000
+				|| (lastPopupMessage.MessageType != item.MessageType)
+				|| item.MessageType == CAN_POPUP_MSG_HANDBRAKE
+				|| item.MessageType
+						== CAN_POPUP_MSG_ENGINE_OIL_PRESSURE_FAULT_STOP_THE_VEHICLE) {
+
+			PushPopupMsg(&item, canSemaphore, popupMessageQueue);
+			previousCanPopupTime = millis();
+		}
+
+	}
+
+	void Process(unsigned long currentTime) {
+
+		if (GetEngineRunning() && !automaticLightingShownOnEngineRunning
+				&& automaticLightingShownOnIgnition) {
+			PushPopupMsg(&itemlight, canSemaphore, popupMessageQueue);
+			automaticLightingShownOnEngineRunning = true;
+		}
+
+		if (canBeVisible && !IsPopupVisible()
+				&& !popupMessageQueue->isEmpty()) {
+
+			xSemaphoreTake(canSemaphore, portMAX_DELAY);
+			popupMessageQueue->pop(&currentPopupMessage);
+			xSemaphoreGive(canSemaphore);
+
+			ShowCanPopupMessage(currentPopupMessage.Category, currentPopupMessage.MessageType, currentPopupMessage.KmToDisplay, currentPopupMessage.DoorStatus1, currentPopupMessage.DoorStatus2, currentPopupMessage.Counter);
+			lastPopupMessage = currentPopupMessage;
+		}
+
+		if (((millis() - canDisplayPopupStartTime) > CAN_POPUP_MESSAGE_TIME)
+				&& popupVisible) {
+			HideCanPopupMessage(currentPopupMessage.MessageType,
+					currentPopupMessage.DoorStatus1,
+					currentPopupMessage.Counter);
+
+			canDisplayPopupStartTime = 0;
+		}
+
+	}
+
+	void ShowCanPopupMessage(uint8_t category, uint8_t messageType,
+			int kmToDisplay, uint8_t doorStatus1, uint8_t doorStatus2,
+			int counter) {
+
+		CanDisplayPacketSender displayMessageSender(canMessageSender);
+		canDisplayPopupStartTime = millis();
+
+		popupVisible = true;
+		uint8_t messageSentCount = 0;
+
+		while (messageSentCount < CAN_POPUP_MESSAGE_SEND_COUNT) {
+			displayMessageSender.ShowPopup(category, messageType, kmToDisplay,
+					doorStatus1, doorStatus2);
+			messageSentCount++;
+
+			vTaskDelay(5 / portTICK_PERIOD_MS);
+		}
+
+	}
+
+	void ShowCanDoorPopUp() {
+		ShowCanPopupMessage(currentPopupMessage.Category,currentPopupMessage.MessageType, currentPopupMessage.KmToDisplay, currentPopupMessage.DoorStatus1,	currentPopupMessage.DoorStatus2, currentPopupMessage.Counter);
+	}
+
+	void HideCanPopupMessage(uint8_t messageType, uint8_t doorStatus, int counter) {
+		CanDisplayPacketSender displayMessageSender(canMessageSender);
+		uint8_t messageSentCount = 0;
+		while (messageSentCount < CAN_POPUP_MESSAGE_SEND_COUNT) {
+			displayMessageSender.HidePopup(messageType);
+			messageSentCount++;
+			vTaskDelay(5 / portTICK_PERIOD_MS);
+		}
+		lastPopupMessage.DisplayTimeInMilliSeconds = 0;
+		popupVisible = false;
+		previousCanPopupTime = millis();
+
+	}
+
+	void HideCurrentPopupMessage() {
+		HideCanPopupMessage(lastPopupMessage.MessageType,
+				lastPopupMessage.DoorStatus1, lastPopupMessage.Counter);
+	}
+
+	bool IsPopupVisible() {
+		return popupVisible;
+	}
+
+	void SetEngineRunning(bool enrunn) {
+		enginerunning = enrunn;
+	}
+
+	bool GetEngineRunning() {
+		return enginerunning;
+	}
+
+	void SetIgnition(bool ign) {
+		ignition = ign;
+	}
+
+	bool GetIgnition() {
+		return ignition;
+	}
+
+	void Reset() {
+		lastPopupMessage.IsInited = false;
+		xSemaphoreTake(canSemaphore, portMAX_DELAY);
+		popupMessageQueue->flush();
+		xSemaphoreGive(canSemaphore);
+		lastPopupMessage.DisplayTimeInMilliSeconds = 0;
+		lastPopupMessage.Visible = false;
+		lastPopupMessage.Visible = false;
+		riskOfIceShown = false;
+		canDisplayPopupStartTime = 0;
+		automaticLightingShownOnEngineRunning = false;
+		automaticLightingShownOnIgnition = false;
+		automaticDoorLockShownOnEngineRunning = false;
+		automaticDoorLockShownOnIgnition = false;
+		enginerunning = false;
+
+		ResetSeatBeltWarning();
+		HideCurrentPopupMessage();
+	}
+
+	void ResetSeatBeltWarning() {
+		seatbeltWarningShown = false;
+		if (lastPopupMessage.MessageType
+				== CAN_POPUP_MSG_FRONT_SEAT_BELTS_NOT_FASTENED
+				&& IsPopupVisible()) {
+			HideCanPopupMessage(lastPopupMessage.MessageType,
+					lastPopupMessage.DoorStatus1, lastPopupMessage.Counter);
+		}
+	}
+private:
+
+	AbstractCanMessageSender *canMessageSender;
+	//ByteAcceptanceHandler* byteAcceptanceHandler;
+
+	bool riskOfIceShown = false;
+	bool seatbeltWarningShown = false;
+	bool automaticLightingShownOnIgnition = false;
+	bool automaticLightingShownOnEngineRunning = false;
+	bool automaticDoorLockShownOnEngineRunning = false;
+	bool automaticDoorLockShownOnIgnition = false;
+	bool popupVisible = false;
+	bool enginerunning = false;
+	bool ignition = false;
+	bool canBeVisible = true;
+	unsigned long canDisplayPopupStartTime = 0;
+	unsigned long previousCanPopupTime = millis();
+	CanDisplayPopupItem currentPopupMessage;
+	CanDisplayPopupItem lastPopupMessage;
+	CanDisplayPopupItem itemlight;
+	CanDisplayPopupItem itemdoor;
+	Queue *popupMessageQueue;
+	SemaphoreHandle_t canSemaphore;
+
+	
+	const uint8_t CAN_POPUP_MESSAGE_SEND_COUNT = 2;
+	const int chillTime = 10;//time to wait between display popups with the same ID (it's annoying when the same popups display a long time)
+
+	void PushPopupMsg(CanDisplayPopupItem *item, SemaphoreHandle_t sem,
+			Queue *q) {
+		xSemaphoreTake(sem, portMAX_DELAY);
+		q->push(item);
+		xSemaphoreGive(sem);
+	}
+
+};
+
+#endif

--- a/src/Van/Handlers/VanCarStatusWithTripComputerHandler.h
+++ b/src/Van/Handlers/VanCarStatusWithTripComputerHandler.h
@@ -82,8 +82,8 @@ public:
         doorStatus.status.RearRight = packet.data.Doors.RearRight;
         doorStatus.status.BootLid = packet.data.Doors.BootLid;
 
-        if (doorStatus.asByte != 0)
-        {
+       // if (doorStatus.asByte != 0)
+      //  {
             CanDisplayPopupItem item;
             item.DisplayTimeInMilliSeconds = CAN_POPUP_DOOR_MESSAGE_TIME;
             item.Category = CAN_POPUP_MSG_SHOW_CATEGORY1;
@@ -97,7 +97,7 @@ public:
             item.SetVisibleOnDisplayTime = 0;
             item.VANByte = 0x02;
             canPopupHandler->QueueNewMessage(item);
-        }
+      //  }
 
         return true;
     }

--- a/src/Van/Handlers/VanDisplayHandlerV2.h
+++ b/src/Van/Handlers/VanDisplayHandlerV2.h
@@ -214,7 +214,7 @@ public:
             leftStickButtonReturn = currentTime + LEFT_STICK_BUTTON_TIME;
             ignitionDataToBridge.LeftStickButtonPressed = 1;
             dataToBridge.LeftStickButtonPressed = 1;
-            //canTripInfoHandler->TripButtonPress();
+            canTripInfoHandler->TripButtonPress();
         }
 
         if (currentTime > leftStickButtonReturn)

--- a/src/Van/Handlers/VanDisplayHandlerV2.h
+++ b/src/Van/Handlers/VanDisplayHandlerV2.h
@@ -214,7 +214,7 @@ public:
             leftStickButtonReturn = currentTime + LEFT_STICK_BUTTON_TIME;
             ignitionDataToBridge.LeftStickButtonPressed = 1;
             dataToBridge.LeftStickButtonPressed = 1;
-            canTripInfoHandler->TripButtonPress();
+            //canTripInfoHandler->TripButtonPress();
         }
 
         if (currentTime > leftStickButtonReturn)


### PR DESCRIPTION
I've created new popup handler just like we talked.
Major changes:
All popups are visible with the same time. Popup with door open message is "monitoring" with every call of QueueNewMessage function. Item with type
_CAN_POPUP_MSG_DOORS_BOOT_BONNET_REAR_SCREEN_AND_FUEL_TANK_OPEN_ is showing when door status changes (with ShowCanPopupMessage method) and hiding when door status is equal 0. That's the reason I wanted to have item with door status all the time in QueueNewMessage.
I made an assumption that we want to see messages with automatic lighting active and automatic locking active once per ignition and once per engine running, so I made additional logic to this. 
Another assumption is, we queue messages with the same type with certain period of time or we queue message if previous message was another type. 
I also wrote auxiliary function to push messages to queue, because three lines with semaphore and push to the queue was repeating often. 